### PR TITLE
created EMACS variable to allow users to customize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@
 # Author: Jonas Bernoulli <jonas@bernoul.li>
 # License: GPL v3 <https://www.gnu.org/licenses/gpl-3.0.txt>
 
+EMACS ?= emacs
+
 .PHONY: all help build build-init quick bootstrap
 .FORCE:
 
@@ -19,24 +21,24 @@ help:
 
 build:
 	@rm -f init.elc
-	@emacs -Q --batch -L lib/borg --load borg \
+	@$(EMACS) -Q --batch -L lib/borg --load borg \
 	--funcall borg-initialize \
 	--funcall borg-batch-rebuild 2>&1
 
 build-init:
 	@rm -f init.elc
-	@emacs -Q --batch -L lib/borg --load borg \
+	@$(EMACS) -Q --batch -L lib/borg --load borg \
 	--funcall borg-initialize \
 	--funcall borg-batch-rebuild-init 2>&1
 
 quick:
 	@rm -f init.elc
-	@emacs -Q --batch -L lib/borg --load borg \
+	@$(EMACS) -Q --batch -L lib/borg --load borg \
 	--funcall borg-initialize \
 	--eval  '(borg-batch-rebuild t)' 2>&1
 
 lib/%: .FORCE
-	@emacs -Q --batch -L lib/borg --load borg \
+	@$(EMACS) -Q --batch -L lib/borg --load borg \
 	--funcall borg-initialize \
 	--eval  '(borg-build "$(@F)")' 2>&1
 


### PR DESCRIPTION
I use my own build of emacs so that "emacs" in my PATH is almost always not the one that I use.   Rather than hard-coding "emacs", using a variable allows me to over-ride this, e.g.,
```
EMACS=/path/to/my/build/of/emacs make bootstrap
```