### PR TITLE
init: Require use-package just at compile-time

### DIFF
--- a/init.el
+++ b/init.el
@@ -27,7 +27,8 @@
   (borg-initialize))
 
 (progn ;    `use-package'
-  (require  'use-package)
+  (eval-when-compile
+    (require 'use-package))
   (setq use-package-verbose t))
 
 (use-package subr-x


### PR DESCRIPTION
use-package is only required when byte-compiling init.el.