### PR TITLE
Update branch name for Borg repo in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ bootstrap-borg:
 	@mkdir .git/modules
 	@git clone https://github.com/emacscollective/borg lib/borg \
 	--separate-git-dir .git/modules/borg
-	@cd lib/borg; git symbolic-ref HEAD refs/heads/master
+	@cd lib/borg; git symbolic-ref HEAD refs/heads/main
 	@cd lib/borg; git reset --hard HEAD
 
 else


### PR DESCRIPTION
I tried to set up a new machine with my emacs.g/Borg-based Emacs config earlier, and found that `make bootstrap-borg` failed unless I changed `master` to `main`.